### PR TITLE
Add Sony DualShock 4 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ None yet.
 
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
-* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - USB/Bluetooth Gamepads (see demos section)
+* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see demos section)
 
 
 ### Candidates

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ None yet.
 
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and [blinkstick-node](https://github.com/arvydas/blinkstick-node))
+* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - USB/Bluetooth Gamepads (see demos section, and [WebHID-DS4](https://github.com/TheBITLINK/WebHID-DS4))
 
 
 ### Candidates
@@ -94,6 +95,7 @@ None yet.
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
+* [TheBITLINK/WebHID-DS4](https://thebitlink.github.io/WebHID-DS4/) - using a DualShock 4 controller.
 
 
 ## Real-world applications

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ None yet.
 ## Devices
 *Devices that work well with WebHID, and device-specific abstraction libraries. Do also file an issue to inform others of devices that don't. Not all devices in the USB HID device class will communicate using the high-level abstractions.*
 
-* [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and [node-blink1](https://github.com/sandeepmistry/node-blink1)).
-* [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and [blinkstick-node](https://github.com/arvydas/blinkstick-node))
-* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - USB/Bluetooth Gamepads (see demos section, and [WebHID-DS4](https://github.com/TheBITLINK/WebHID-DS4))
+* [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
+* [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
+* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - USB/Bluetooth Gamepads (see demos section)
 
 
 ### Candidates

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Devices](#devices)
 - [Tools](#tools)
 - [Bluetooth, USB, & HID reference](#bluetooth-usb--hid-reference)
+- [Libraries](#libraries)
 - [Demos, experiments & hacks](#demos-experiments--hacks)
 - [Real-world applications](#real-world-applications)
 - [Inspiration from elsewhere](#inspiration-from-elsewhere)
@@ -62,7 +63,7 @@ None yet.
 
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
-* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see demos section)
+* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
 
 
 ### Candidates
@@ -92,10 +93,13 @@ None yet.
 * [Understanding HID report descriptors](https://who-t.blogspot.com/2018/12/understanding-hid-report-descriptors.html) - Understanding devices' descriptions of themselves.
 
 
+## Libraries
+* [TheBITLINK/WebHID-DS4](https://thebitlink.github.io/WebHID-DS4/) - using a DualShock 4 controller.
+
+
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
-* [TheBITLINK/WebHID-DS4](https://thebitlink.github.io/WebHID-DS4/) - using a DualShock 4 controller.
 
 
 ## Real-world applications

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ None yet.
 * [Espruino Pico](https://www.espruino.com/Pico) board - has an [USB HID mode](https://www.espruino.com/USB), might also be useful as an emulator?
 * Jabra headsets (see [Standard USB HID Specification](https://developer.jabra.com/site/global/sdks/web/index.gsp))
 * Nintendo Switch Pro Controller<sup>[(ref)](https://chromium.googlesource.com/chromium/src.git/+/05ac99d21920fec606ac1e360a2534921938cc85)</sup>
-* Sony DualShock 3 & 4<sup>[(ref)](https://chromium.googlesource.com/chromium/src.git/+/05ac99d21920fec606ac1e360a2534921938cc85)</sup>
+* Sony DualShock 3<sup>[(ref)](https://chromium.googlesource.com/chromium/src.git/+/05ac99d21920fec606ac1e360a2534921938cc85)</sup>
 * [X-keys](https://xkeys.com/xkeys.html) - keyboards, switches, analog controls, and pedals (see [HID Data Reports](https://xkeys.com/software/developer/developerhiddatareports.html), [Integration](https://xkeys.com/software/developer/developerintegration.html), [xkeys](https://github.com/SuperFlyTV/xkeys), [node-xkeys](https://github.com/macoss/node-xkeys))
 * Xbox Wireless Controller<sup>[(ref)](https://chromium.googlesource.com/chromium/src.git/+/05ac99d21920fec606ac1e360a2534921938cc85)</sup>
 


### PR DESCRIPTION
I made a library that provides a high level API for DualShock 4 controllers over WebHID.

I'm not sure where to add it since i intend it to be more of a library than just a demo, but for now i added it to the Demos and Devices sections (maybe there should be a new section for abstraction libraries built over WebHID?)