### PR TITLE
Add elgato stream-deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ None yet.
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
 * [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
-* [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see libraries section)
+* [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see demos section, and prior art [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck))
 
 
 ### Candidates
@@ -96,13 +96,12 @@ None yet.
 
 ## Libraries
 * [TheBITLINK/WebHID-DS4](https://thebitlink.github.io/WebHID-DS4/) - using a DualShock 4 controller.
-* [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70) - using an Elgato Stream Deck.
 
 
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
-* [node-elgato-stream-deck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck.
+* [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via WIP enhancement to [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
 
 
 ## Real-world applications

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ None yet.
 *Devices that work well with WebHID, and device-specific abstraction libraries. Do also file an issue to inform others of devices that don't. Not all devices in the USB HID device class will communicate using the high-level abstractions.*
 
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
-* [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
-* [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see demos section, and prior art [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck))
+* [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick](https://github.com/arvydas/blinkstick-node))
+* [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see demos section, and prior art [elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck))
 * [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
 
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ None yet.
 
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
-* [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via WIP enhancement to [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
+* [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via [WIP enhancement to node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
 
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ None yet.
 
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
-* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
 * [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see demos section, and prior art [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck))
+* [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
 
 
 ### Candidates
@@ -100,8 +100,8 @@ None yet.
 
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
-* [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
 * [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via WIP enhancement to [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
+* [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
 
 
 ## Real-world applications

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ None yet.
 
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
-* [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via [WIP enhancement to node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
+* [Elgato StreamDeck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck (via [WIP enhancement to elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70)).
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
 
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ None yet.
 * [Blink(1)](https://blink1.thingm.com) - notification light (see demos section, and prior art [node-blink1](https://github.com/sandeepmistry/node-blink1)).
 * [BlinkStick](https://www.blinkstick.com) - light devices and controllers (see demos section, and prior art [blinkstick-node](https://github.com/arvydas/blinkstick-node))
 * [Sony DualShock 4](https://www.playstation.com/en-us/explore/accessories/gaming-controllers/dualshock-4/) - controller for PlayStation 4 (see libraries section)
+* [Elgato Stream Deck](https://www.elgato.com/en/gaming/stream-deck) - programmable button panel (see libraries section)
 
 
 ### Candidates
@@ -95,11 +96,13 @@ None yet.
 
 ## Libraries
 * [TheBITLINK/WebHID-DS4](https://thebitlink.github.io/WebHID-DS4/) - using a DualShock 4 controller.
+* [node-elgato-stream-deck](https://github.com/Lange/node-elgato-stream-deck/pull/70) - using an Elgato Stream Deck.
 
 
 ## Demos, experiments & hacks
 * [todbot/blink1-webhid](https://todbot.github.io/blink1-webhid/) - using the blink(1) USB light.
 * [robatwilliams/webhid-demos](https://github.com/robatwilliams/webhid-demos) - using the BlinkStick Strip.
+* [node-elgato-stream-deck](https://streamdeck.julusian.dev/) - using the Elgato Stream Deck.
 
 
 ## Real-world applications


### PR DESCRIPTION
I have been playing around with porting the (node-elgato-stream-deck)[https://github.com/lange/node-elgato-stream-deck] library to run on webhid.
Its currently sat in a branch as I don't want to rush into releasing it when the webhid api could still change, but it is ready to link to from here now.

I have included the demo project that I have been using for development testing, as an easy working demo.